### PR TITLE
moved alerts from behind crisp

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
-  z-index: 1000;
+  bottom: 22px;
+  right: 95px;
+  z-index: 100;
 }


### PR DESCRIPTION
<img width="501" alt="Screen Shot 2021-09-01 at 12 33 41 PM" src="https://user-images.githubusercontent.com/46946590/131656962-2232dd5c-b555-4b64-a417-d3b498e44fb4.png">
